### PR TITLE
reduce dns.resolvedSrv() times

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,9 @@
 const Dns = require('dns');
 const HttpAgent = require('http').Agent;
 
+let resolvedRsv = {};
+const lastResolvedTimes = {};
+const resolvedIntervalMs = 10 * 60 * 1000; // 10 mintues
 const internals = {};
 
 internals.compareNumbers = function compareNumbers(a, b) {
@@ -67,13 +70,35 @@ internals.groupSrvRecords = function groupSrvRecords(addrs) {
     return result;
 };
 
-
 internals.rewriteOutputHeader = function (req, header) {
 
     const endOfHeader = header.indexOf('\r\n\r\n') + 4;
     return req._header + header.substring(endOfHeader);
 };
 
+const resolveSrv = (srvRecord) =>
+
+    new Promise((resolve, reject) => {
+
+        if (srvRecord in resolvedRsv && Date.now() - lastResolvedTimes[srvRecord] > resolvedIntervalMs) {
+            return resolve();
+        }
+
+        // If there has no corresponding key in the resolvedRsv object,
+        // or the last resolved time is out of 5 minutes,
+        // then, resolved srv record againt.
+        // Otherwise, get the value from the memory
+        Dns.resolveSrv(srvRecord, (err, addrs) => {
+
+            if (err) {
+                return reject(err);
+            }
+
+            lastResolvedTimes[srvRecord] = Date.now();
+            resolvedRsv = Object.assign(resolvedRsv, { [srvRecord]: addrs });
+            return resolve();
+        });
+    });
 
 const ServiceAgent = class extends HttpAgent {
 
@@ -98,36 +123,42 @@ const ServiceAgent = class extends HttpAgent {
     /* override */
     addRequest(req, options, ...extra) {
 
-        Dns.resolveSrv(this.service + options.host, (err, addrs) => {
+        const srvRecord = this.service + options.host;
+        resolveSrv(srvRecord)
+            .then((xhr) => {
 
-            if (err || addrs.length === 0) {
-                // use passed in values
+                const addrs = resolvedRsv[srvRecord];
+                if (addrs.length === 0) {
+                    throw new Error('Has no mapped value');
+                }
+
+                const addr = internals.groupSrvRecords(addrs).shift();
+
+                // regenerating stored HTTP header string for request
+                // note: blatantly ripped from http-proxy-agent
+                req._header = null;
+                req.setHeader('host', addr.name + ':' + (addr.port || options.port));
+                req._implicitHeader();
+
+                // rewrite host name in response
+
+                if (req.outputData) {    // v11+
+                    if (req.outputData.length > 0) {
+                        req.outputData[0].data = internals.rewriteOutputHeader(req, req.outputData[0].data);
+                    }
+                }
+                else if (req.output) {   // legacy
+                    if (req.output.length > 0) {
+                        req.output[0] = internals.rewriteOutputHeader(req, req.output[0]);
+                    }
+                }
+
+                return super.addRequest(req, addr.name, addr.port || options.port, options.localAddress);
+            })
+            .catch(() => {
+
                 return super.addRequest(req, options, ...extra);
-            }
-
-            const addr = internals.groupSrvRecords(addrs).shift();
-
-            // regenerating stored HTTP header string for request
-            // note: blatantly ripped from http-proxy-agent
-            req._header = null;
-            req.setHeader('host', addr.name + ':' + (addr.port || options.port));
-            req._implicitHeader();
-
-            // rewrite host name in response
-
-            if (req.outputData) {    // v11+
-                if (req.outputData.length > 0) {
-                    req.outputData[0].data = internals.rewriteOutputHeader(req, req.outputData[0].data);
-                }
-            }
-            else if (req.output) {   // legacy
-                if (req.output.length > 0) {
-                    req.output[0] = internals.rewriteOutputHeader(req, req.output[0]);
-                }
-            }
-
-            return super.addRequest(req, addr.name, addr.port || options.port, options.localAddress);
-        });
+            });
     }
 };
 


### PR DESCRIPTION
Pick up the resolve-value from the resolved rsv-object.
If the last resolved time is passed over 10 minutes, resolve the record again.